### PR TITLE
 Remove deprecated `yield $generator` syntax

### DIFF
--- a/src/kingofturkey38/voting38/Main.php
+++ b/src/kingofturkey38/voting38/Main.php
@@ -89,7 +89,7 @@ class Main extends PluginBase implements Listener{
 				while($player->isOnline() && $this->getServer()->isRunning()){
 					$this->checkVote($player, false);
 
-					yield $this->std->sleep(20 * 30);
+					yield from $this->std->sleep(20 * 30);
 				}
 			});
 		}


### PR DESCRIPTION
https://github.com/SOF3/await-generator/blob/3a8286c5240695cc8bfdd5495160ebb247e6ee8e/CHANGELOG.md?plain=1#L24